### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   trivy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mellowdrifter/bgpwatch/security/code-scanning/1](https://github.com/mellowdrifter/bgpwatch/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current functionality (`actions/checkout` and scanning) while preventing unnecessary write scopes if repository defaults are broader.

Edit `.github/workflows/security.yml` near the top-level keys (`name`, `on`, `jobs`) and insert `permissions` between `on` and `jobs` (or anywhere at root level).

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
